### PR TITLE
Change the path of the website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,5 +49,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./staging
+          publish_dir: ./staging/hadoop-project
 

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 
 Build and push Apache Hadoop (trunk) document automatically via GitHub Actions.
 
-* https://aajisaka.github.io/hadoop-document/hadoop-project/
+* https://aajisaka.github.io/hadoop-document/
 


### PR DESCRIPTION
Shorten the URL to check the deployments easily from: https://github.com/aajisaka/hadoop-document/deployments/activity_log?environment=github-pages

Old site: https://aajisaka.github.io/hadoop-document/hadoop-project/
New site: https://aajisaka.github.io/hadoop-document/